### PR TITLE
Restore yarnrc removal

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,3 +1,0 @@
-disturl "https://electronjs.org/headers"
-target "13.1.8"
-runtime "electron"


### PR DESCRIPTION
The other patches related to this removal have been kept but this file managed to make it back in.

The problem with the yarnrc is that it compiles modules for the wrong target (Electron) so we get Node module version errors among other issues (like "module did not self-register" whatever that means).

For anyone looking to replicate use this Dockerfile:

```
FROM debian:11

RUN apt-get update \
 && apt-get install -y \
    git \
    curl \
    build-essential \
    g++ \
    libx11-dev \
    libxkbfile-dev \
    libsecret-1-dev \
    python-is-python3 \
    jq

RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -

RUN apt-get update && apt-get install -y \
  nodejs

RUN npm install -g yarn

RUN git clone https://github.com/cdr/code-server.git
```

1. Save the above as Dockerfile into an empty directory
2. `cd` to that directory
3.  Run `docker build . -t code-server-test`
4. Run `docker run --rm code-server-test bash -c 'cd code-server && yarn && yarn watch`
5. Observe eventual spdlog error
6. Kill container
7. Run `docker run --rm code-server-test bash -c 'cd code-server/vendor && yarn add --modules-folder modules --ignore-scripts --dev code-oss-dev@code-asher/vscode#e225960dcaa469a134865b17169b6ebd3c45dd3f && cd .. && yarn && yarn watch`
8. No spdlog errors!