### PR TITLE
Restore yarnrc removal

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,3 +1,0 @@
-disturl "https://electronjs.org/headers"
-target "13.1.8"
-runtime "electron"


### PR DESCRIPTION
Looks like the commit from https://github.com/cdr/vscode/pull/4 was lost