### PR TITLE
Fix missing files

### DIFF
--- a/build/gulpfile.vscode.server.js
+++ b/build/gulpfile.vscode.server.js
@@ -30,11 +30,11 @@ const REPO_ROOT = path.dirname(__dirname);
 const commit = util.getVersion(REPO_ROOT);
 const BUILD_ROOT = path.dirname(REPO_ROOT);
 
-// Put files here that need to be packaged that are not already in the entry
-// points or included by the entry points.  The optimize step bundles code into
-// each entry point that imports it but more interestingly adding files here
-// that would normally get bundled causes the bundling to fail resulting in
-// "multiple top-level define" errors from the loader.
+// Put files here that need to be packaged that are not entry points or imported
+// by an entry point.  The optimize step bundles each entry point into a single
+// file and for some reason adding files here that would normally get bundled
+// causes them (and their imports) not to get bundled.  In the worst case this
+// can cause multiple top-level define errors, other times it causes 404s.
 const vscodeServerResources = [
 	// Bootstrap
 	'out-build/main.js',
@@ -48,12 +48,10 @@ const vscodeServerResources = [
 	'out-build/bootstrap-window.js',
 
 	// Base
-	'out-build/vs/base/common/performance.js',
-	'out-build/vs/base/node/languagePacks.js',
-	'out-build/vs/base/node/{stdForkStart.js,terminateProcess.sh,cpuUsage.sh,ps.sh}',
-	'out-build/vs/base/browser/ui/codicons/codicon/**',
-	'out-build/vs/base/parts/sandbox/electron-browser/preload.js',
-	'out-build/vs/platform/environment/node/userDataPath.js',
+	'out-build/vs/base/**/*',
+
+	// Platform
+	'out-build/vs/platform/**/*',
 
 	// Workbench
 	'out-build/vs/code/browser/workbench/service-worker.js',


### PR DESCRIPTION
Before:
![error](https://user-images.githubusercontent.com/45609798/138356886-229e2c11-28d7-4286-8f32-baf4866fa9c2.png)

After:
![fixed](https://user-images.githubusercontent.com/45609798/138357748-2f417b50-f51d-4824-8802-8cb3126f932c.png)

As near as I can gather it goes something like this:
  1. Optimizer traverses imports and adds the code to the bundle
  2. Optimizer excludes files in the resources array
  3. When the optimizer excludes a file it also excludes all of that file's imports (and so on)
  4. As a result if a bundle imports file A which is not in the resources array but is imported by another file B which _is_ in the resources array it will 404 because file A is not bundled due to being excluded **and** not copied since it was not in the resources array.

We cannot put all files into the resources array to fix this either because as we previously discovered that results in the multiple top-level define error (when nothing is bundled the bundler appears to generate an invalid bundle; the output is completely different).  And we want bundles anyway since they will provide a faster experience.