### PR TITLE
Enable proposed API by default

### DIFF
--- a/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
+++ b/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
@@ -1132,6 +1132,9 @@ class ProposedApiController {
 			(_environmentService.isExtensionDevelopment && productService.quality !== 'stable') || // do not allow proposed API against stable builds when developing an extension
 			(this.enableProposedApiFor.length === 0 && Array.isArray(_environmentService.extensionEnabledProposedApi)); // always allow proposed API if --enable-proposed-api is provided without extension ID
 
+		// NOTE@coder: Always enable the proposed API.
+		this.enableProposedApiForAll = true;
+
 		this.productAllowProposedApi = new Set<string>();
 		if (isNonEmptyArray(productService.extensionAllowedProposedApi)) {
 			productService.extensionAllowedProposedApi.forEach((id) => this.productAllowProposedApi.add(ExtensionIdentifier.toKey(id)));


### PR DESCRIPTION
Turns out we used to already do this and if you passed the flag you
would actually *disable* the global enable setting.  This is because we
were defaulting to an empty array which means to enable it globally.

Fixes https://github.com/cdr/code-server/issues/4397
Fixes https://github.com/cdr/code-server/issues/4480
