### PR TITLE
fix(webClientServer): include basePath in createRequestUrl

### DIFF
--- a/src/vs/server/webClientServer.ts
+++ b/src/vs/server/webClientServer.ts
@@ -319,7 +319,7 @@ export class WebClientServer {
 					webEndpointUrl: this.createRequestUrl(req, parsedUrl, '/static').toString(),
 					webEndpointUrlTemplate: this.createRequestUrl(req, parsedUrl, '/static').toString(),
 
-					updateUrl: this.createRequestUrl(req, parsedUrl, '/update/check').toString(),
+					updateUrl: './update/check'
 				},
 				folderUri: (workspacePath && isFolder) ? transformer.transformOutgoing(URI.file(workspacePath)) : undefined,
 				workspaceUri: (workspacePath && !isFolder) ? transformer.transformOutgoing(URI.file(workspacePath)) : undefined,


### PR DESCRIPTION
## Description 
This patches the `webClientServer` to ensure the `updateUrl` is relative to the root.
This ensures the correct URL in case code-server is being served behind a
reverse proxy.

An example of this would be using Caddy to server code-server on
localhost:8082/code/

This fix ensures request urls are created against localhost:8082/code/ instead
of localhost:8082/

### Screenshot

Notice the Request URL in the image. Serving code-server regularly (i.e. on 8080), the update/check is made against the root.
<img width="1680" alt="Screen Shot 2021-11-17 at 2 50 47 PM" src="https://user-images.githubusercontent.com/3806031/142289196-fccf507f-3806-4cc3-9874-ed727d5a3506.png">

When serving code-server behind a reverse-proxy with Caddy, the update/check is made against the reverse-proxy root (i.e. `/code/`

<img width="1680" alt="Screen Shot 2021-11-17 at 2 50 43 PM" src="https://user-images.githubusercontent.com/3806031/142289208-6353209b-0f08-4a30-afee-e126e46ec2c3.png">

### Testing Plan

I tested against the root and the reverse-proxy.

1. `cd vscode && git checkout jsjoeio-fix-csp-reverse-proxy`
2. `yarn link`
3. `cd code-server && yarn link code-oss-dev --modules-folder vendor/modules`
4. create `Caddyfile` somewhere:
```Caddyfile
http://localhost:8082/code/* {
  uri strip_prefix /code
  reverse_proxy 127.0.0.1:8080
}
```
5. `caddy run`
6. Navigate to `http://localhost:8082/code/` in the browser and check Network tab. Filter for "check" and look at the Headers tab for the request.

I also did some basic testing around `new URL` in Codesandbox [here](https://codesandbox.io/s/interesting-babbage-s36t0?file=/hello.test.ts).
 
This PR fixes https://github.com/cdr/code-server/issues/4476

(There is a chance this fixes other reverse proxy issues, but I will test after this is merged).
