### PR TITLE
Fix issues surrounding persisted workspaces.

### DIFF
--- a/src/vs/base/common/uri.ts
+++ b/src/vs/base/common/uri.ts
@@ -701,3 +701,13 @@ function percentDecode(str: string): string {
 	}
 	return str.replace(_rEncodedAsHex, (match) => decodeURIComponentGraceful(match));
 }
+
+/**
+ * Encode a path for opening via the folder or workspace query parameter. This
+ * preserves slashes so it can be edited by hand more easily.
+ *
+ * @author coder
+ */
+export const encodePath = (path: string): string => {
+	return path.split('/').map((p) => encodeURIComponent(p)).join('/');
+};

--- a/src/vs/code/browser/workbench/workbench.ts
+++ b/src/vs/code/browser/workbench/workbench.ts
@@ -10,7 +10,7 @@ import { Emitter, Event } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { Schemas } from 'vs/base/common/network';
 import { isEqual } from 'vs/base/common/resources';
-import { URI, UriComponents } from 'vs/base/common/uri';
+import { encodePath, URI, UriComponents } from 'vs/base/common/uri';
 import { generateUuid } from 'vs/base/common/uuid';
 import { request } from 'vs/base/parts/request/browser/request';
 import { localize } from 'vs/nls';
@@ -36,16 +36,6 @@ function doCreateUri(path: string, queryValues: Map<string, string>): URI {
 
 	return URI.parse(window.location.href).with({ path, query });
 }
-
-/**
- * Encode a path for opening via the folder or workspace query parameter. This
- * preserves slashes so it can be edited by hand more easily.
- *
- * @author coder
- */
-export const encodePath = (path: string): string => {
-	return path.split('/').map((p) => encodeURIComponent(p)).join('/');
-};
 
 interface ICredential {
 	service: string;
@@ -454,11 +444,11 @@ class WindowIndicator implements IWindowIndicator {
 	 * @author coder
 	 */
 	const toRemote = (value: string): string => {
-		if (value.startsWith("/")) {
-			return "vscode-remote://" + value;
+		if (value.startsWith('/')) {
+			return 'vscode-remote://' + value;
 		}
-		return value
-	}
+		return value;
+	};
 
 	const query = new URL(document.location.href).searchParams;
 	query.forEach((value, key) => {


### PR DESCRIPTION
This PR addresses https://github.com/cdr/code-server/issues/4487, specifically extending VS Code’s existing desktop workspace behaviors to the browser. This may also address `—ignore-last-opened` by making the new tab behavior match [the user’s initial path arguments.](url) 
https://github.com/cdr/vscode/blob/c1494438479e8382794576f2c621081d52b4fdc1/src/vs/workbench/browser/web.main.ts#L223-L243
