### PR TITLE
fix(webClientServer): use relative path in logoutEndpointUrl

### DIFF
--- a/src/vs/server/webClientServer.ts
+++ b/src/vs/server/webClientServer.ts
@@ -314,7 +314,7 @@ export class WebClientServer {
 					},
 
 					// Endpoints
-					logoutEndpointUrl: this.createRequestUrl(req, parsedUrl, '/logout').toString(),
+					logoutEndpointUrl: './logout',
 					webEndpointUrl: this.createRequestUrl(req, parsedUrl, '/static').toString(),
 					webEndpointUrlTemplate: this.createRequestUrl(req, parsedUrl, '/static').toString(),
 


### PR DESCRIPTION
## Description 
This patches the `webClientServer` to ensure the `logoutEndpointUrl` is relative to the root.
This ensures the correct URL in case code-server is being served behind a
reverse proxy.

An example of this would be using Caddy to server code-server on
localhost:8082/code/

This fix ensures logging out makes a request to localhost:8082/code/logout instead
of localhost:8082/logout

### Video

#### Before

https://user-images.githubusercontent.com/3806031/143142521-b5b27965-a5be-4ba4-bf1f-99e677d06406.mov

#### After

https://user-images.githubusercontent.com/3806031/143142586-0c4f72a0-e7b9-45b9-908d-e29a07337942.mov

### Testing Plan

I tested against the root and the reverse-proxy.

1. `cd vscode && git checkout jsjoeio-fix-csp-reverse-proxy`
2. `yarn link`
3. `cd code-server && yarn link code-oss-dev --modules-folder vendor/modules`
4. create `Caddyfile` somewhere:
```Caddyfile
http://localhost:8082/code/* {
  uri strip_prefix /code
  reverse_proxy 127.0.0.1:8080
}
```
5. `caddy run`
6. Navigate to `http://localhost:8082/code/` in the browser
7. Open Menu and click Sign out
 
[This PR fixes https://github.com/cdr/code-server/issues/4476](https://github.com/cdr/code-server/issues/4503)

(There is a chance this fixes other reverse proxy issues, but I will test after this is merged).
