### PR TITLE
fix(webServerClient): use relative static path for icons

### DIFF
--- a/src/vs/server/webClientServer.ts
+++ b/src/vs/server/webClientServer.ts
@@ -210,7 +210,7 @@ export class WebClientServer {
 			'background-color': clientTheme.backgroundColor,
 			description: 'Run editors on a remote server.',
 			icons: this._iconSizes.map((size => ({
-				src: this.createRequestUrl(req, parsedUrl, `/static/resources/server/code-${size}.png`).toString(),
+				src: `./static/resources/server/code-${size}.png`,
 				type: 'image/png',
 				sizes: `${size}x${size}`,
 			})))


### PR DESCRIPTION
## Description

This PR fixes an issue with the icon in the `webManifest` where the icon wasn't being served correctly behind a reverse proxy.

## Screenshot

### Before

Error in console because it's being served from localhost:8082
![image](https://user-images.githubusercontent.com/3806031/143144714-39440a88-2fd8-4bf1-ad06-8b88ff4343a6.png)

### After

No error in console because it uses a relative path

![image](https://user-images.githubusercontent.com/3806031/143144797-187e732a-f72b-406e-af28-ac0a020376b7.png)

This PR fixes N/A
