### PR TITLE
Add back sanitization of our env variables

### DIFF
--- a/src/vs/base/common/processes.ts
+++ b/src/vs/base/common/processes.ts
@@ -111,6 +111,8 @@ export function sanitizeProcessEnvironment(env: IProcessEnvironment, ...preserve
 		/^VSCODE_.+$/,
 		/^SNAP(|_.*)$/,
 		/^GDK_PIXBUF_.+$/,
+		/^CODE_SERVER_.+$/,
+		/^CS_.+$/,
 	];
 	const envKeys = Object.keys(env);
 	envKeys


### PR DESCRIPTION
This partially fixes https://github.com/cdr/code-server/issues/4519.

We use an environment variable to distinguish the parent process from
the child so without sanitizing when you spawn code-server from VS Code
it always looks like we are in the parent and the process will fail
since it is not actually the child.
