### PR TITLE
Remove last opened functionality

### DIFF
--- a/src/vs/server/@types/code-server-lib/index.d.ts
+++ b/src/vs/server/@types/code-server-lib/index.d.ts
@@ -18,7 +18,6 @@ declare global {
 		export interface ServerParsedArgs {
 			//#region
 			auth?: AuthType;
-			'ignore-last-opened'?: boolean;
 			//#endregion
 
 			port?: string;

--- a/src/vs/server/serverEnvironmentService.ts
+++ b/src/vs/server/serverEnvironmentService.ts
@@ -16,7 +16,6 @@ export const serverOptions: OptionDescriptions<ServerParsedArgs> = {
 	//#region @coder
 	'auth': { type: 'string' },
 	'port': { type: 'string' },
-	'ignore-last-opened': { type: 'boolean' },
 	//#endregion
 
 	'pick-port': { type: 'string' },
@@ -73,7 +72,6 @@ export const serverOptions: OptionDescriptions<ServerParsedArgs> = {
 export interface ServerParsedArgs {
 	//#region
 	auth?: AuthType;
-	'ignore-last-opened'?: boolean;
 	//#endregion
 
 	port?: string;
@@ -165,7 +163,6 @@ export interface IServerEnvironmentService extends INativeEnvironmentService {
 	readonly serviceWorkerPath: string;
 	readonly proxyUri: string;
 	readonly auth: AuthType;
-	readonly ignoreLastOpened: boolean;
 	//#endregion
 }
 
@@ -188,10 +185,6 @@ export class ServerEnvironmentService extends NativeEnvironmentService implement
 
 	public get proxyUri(): string {
 		return '/proxy/{port}';
-	}
-
-	public get ignoreLastOpened(): boolean {
-		return !!this.args['ignore-last-opened'];
 	}
 
 	//#endregion

--- a/src/vs/server/webClientServer.ts
+++ b/src/vs/server/webClientServer.ts
@@ -79,7 +79,7 @@ export class WebClientServer {
 		private readonly _environmentService: IServerEnvironmentService,
 		private readonly _logService: ILogService,
 		private readonly _themeService: IServerThemeService,
-		private readonly _productService: IProductService
+		private readonly _productService: IProductService,
 	) { }
 
 	async handle(req: http.IncomingMessage, res: http.ServerResponse, parsedUrl: url.UrlWithParsedQuery): Promise<void> {
@@ -329,7 +329,6 @@ export class WebClientServer {
 					enableSmokeTestDriver: this._environmentService.driverHandle === 'web' ? true : undefined,
 					logLevel: this._logService.getLevel(),
 				},
-				ignoreLastOpened: this._environmentService.ignoreLastOpened,
 				userDataPath: this._environmentService.userDataPath,
 				settingsSyncOptions: !this._environmentService.isBuilt && this._environmentService.args['enable-sync'] ? { enabled: true } : undefined,
 			})))

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -22,12 +22,12 @@ import { IRemoteAgentService } from 'vs/workbench/services/remote/common/remoteA
 import { IFileService } from 'vs/platform/files/common/files';
 import { FileService } from 'vs/platform/files/common/fileService';
 import { Schemas } from 'vs/base/common/network';
-import { IWorkspaceContextService, toWorkspaceFolder } from 'vs/platform/workspace/common/workspace';
+import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { IWorkbenchConfigurationService } from 'vs/workbench/services/configuration/common/configuration';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { setFullscreen } from 'vs/base/browser/browser';
-import { encodePath, URI } from 'vs/base/common/uri';
-import { isRecentFolder, IWorkspaceInitializationPayload, IWorkspacesService } from 'vs/platform/workspaces/common/workspaces';
+import { URI } from 'vs/base/common/uri';
+import { IWorkspaceInitializationPayload } from 'vs/platform/workspaces/common/workspaces';
 import { WorkspaceService } from 'vs/workbench/services/configuration/browser/configurationService';
 import { ConfigurationCache } from 'vs/workbench/services/configuration/common/configurationCache';
 import { ISignService } from 'vs/platform/sign/common/sign';
@@ -68,7 +68,6 @@ import { safeStringify } from 'vs/base/common/objects';
 import { ICredentialsService } from 'vs/workbench/services/credentials/common/credentials';
 import { IndexedDB } from 'vs/base/browser/indexedDB';
 import { CodeServerClientAdditions } from 'vs/workbench/browser/client';
-import { BrowserWorkspacesService } from 'vs/workbench/services/workspaces/browser/workspacesService';
 
 class BrowserMain extends Disposable {
 
@@ -221,68 +220,6 @@ class BrowserMain extends Disposable {
 				return service;
 			})
 		]);
-
-		/**
-		 * Added to persist recent workspaces in the browser.
-		 * These behaviors may disabled with the `--ignore-last-opened` argument.
-		 *
-		 * @author coder
-		 * @example User specified a directory at startup.
-		 * ```sh
-		 * code-server ./path/to/project/
-		 * ```
-		 *
-		 * @example Blank project without CLI arguments,
-		 * using the last opened directory in the browser.
-		 * ```sh
-		 * code-server
-		 * open http://localhost:8000/
-		 * ```
-		 *
-		 * @example Query params override CLI arguments.
-		 * ```sh
-		 * code-server ./path/to/project/
-		 * open http://localhost:8000/?folder=/path/to/different/project
-		 * ```
-		*/
-		const browserWorkspacesService = new BrowserWorkspacesService(storageService, configurationService, logService, fileService, environmentService, uriIdentityService);
-		serviceCollection.set(IWorkspacesService, browserWorkspacesService);
-		const workspace = configurationService.getWorkspace();
-
-		logService.debug('Workspace configuration', {
-			workspaceFolders: workspace.folders,
-			ignoreLastOpened: environmentService.ignoreLastOpened,
-		});
-
-		if (workspace.folders.length === 0 && !environmentService.ignoreLastOpened) {
-			logService.debug('Workspace is empty. Checking for recent folders...');
-
-			const recentlyOpened = await browserWorkspacesService.getRecentlyOpened();
-
-			for (const recent of recentlyOpened.workspaces) {
-				if (isRecentFolder(recent)) {
-					logService.debug('Recent folder found...');
-					const folder = toWorkspaceFolder(recent.folderUri);
-					// Note that the `folders` property should be reassigned instead of pushed into.
-					// This property has a setter which updates the workspace's file cache.
-					workspace.folders = [folder];
-
-
-					/**
-					 * Opening a folder from the browser navigates to a URL including the folder param.
-					 * However, since we're overriding the default state of a blank editor,
-					 * we update the URL query param to match this behavior.
-					 * This is especially useful when a user wants to share a link to server with a specific folder.
-					 *
-					 * @see `WorkspaceProvider.createTargetUrl`
-					 * @see `WorkspaceProvider.QUERY_PARAM_FOLDER`
-					 */
-					const nextQueryParam = `?folder=${encodePath(folder.uri.path)}`;
-					window.history.replaceState(null, '', nextQueryParam);
-					break;
-				}
-			}
-		}
 
 		// Workspace Trust Service
 		const workspaceTrustEnablementService = new WorkspaceTrustEnablementService(configurationService, environmentService);

--- a/src/vs/workbench/services/environment/browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/browser/environmentService.ts
@@ -264,9 +264,6 @@ export class BrowserWorkbenchEnvironmentService implements IWorkbenchEnvironment
 	get disableWorkspaceTrust(): boolean { return true; }
 
 	//#region @coder
-	get ignoreLastOpened(): boolean {
-		return !!this.options.ignoreLastOpened;
-	}
 	get userDataPath(): string {
 		if (!this.options.userDataPath) {
 			throw new Error('userDataPath was not provided to the browser');

--- a/src/vs/workbench/workbench.web.api.ts
+++ b/src/vs/workbench/workbench.web.api.ts
@@ -341,11 +341,6 @@ interface IWorkbenchConstructionOptions {
 	//#region @coder
 
 	/**
-	 * Ignore the last opened folder in the browser.
-	 * @see `BrowserMain#initServices`
-	 */
-	readonly ignoreLastOpened?: boolean
-	/**
 	 * Path to the user data directory.
 	 */
 	readonly userDataPath?: string


### PR DESCRIPTION
We must handle this before we get to the browser because the first thing
it does is create a workspace provider based on the provided workspace
before any services are created which means we cannot fetch settings.
So if we grab the last opened after that is done it has the wrong
workspace and this breaks the close folder functionality (and possibly
other things).

Since it needs to be done on the server I figure I will implement in
code-server to minimize the patch.

https://github.com/cdr/code-server/issues/4619