### PR TITLE
fix(product.json): use "code-server" for name

### DIFF
--- a/product.json
+++ b/product.json
@@ -1,6 +1,6 @@
 {
-	"nameShort": "Code Server",
-	"nameLong": "Code Server",
+	"nameShort": "code-server",
+	"nameLong": "code-server",
 	"applicationName": "code-server",
 	"dataFolderName": ".code-server",
 	"win32MutexName": "codeserver",


### PR DESCRIPTION
This PR makes two changes:
- fixes name in "Help: About" to "code-server (not "Code Server")

## Before

![image](https://user-images.githubusercontent.com/3806031/146275204-03ef6c1d-4f44-4895-9251-d49656e41dd9.png)

## After

![image](https://user-images.githubusercontent.com/3806031/146280393-68902130-2526-4774-ae20-560523ef0199.png)

Partial fix for #https://github.com/cdr/code-server/issues/4629
